### PR TITLE
商品出品編集ページのvalidationとテスト

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -97,7 +97,12 @@ class ItemsController < ApplicationController
                 delivery_date: item_params[:delivery_date],
                 category_index: item_params[:category_index])
     # redirect_to root_path
-    redirect_to "/users/#{current_user.id}"
+    if @item.save
+      redirect_to "/users/#{current_user.id}"
+    else
+      render action: :edit
+    end
+    # redirect_to "/users/#{current_user.id}"
     # ここ↑今はマイページに飛ぶが後で訂正する。「変更しました」を挟むか、商品編集ページに飛ぶようにする。
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,11 +3,12 @@ class Item < ApplicationRecord
   has_one :trading, dependent: :destroy
   has_one :categories
 
-  validates :item_name, presence: true, length: { maximum: 40 }
+  validates :item_name, presence: true, length: { in: 1..40 }
   validates :description, presence: true, length:{maximum: 1000 , message: "must be given please" }
   validates :price, numericality: { only_integer: true, greater_than_or_equal_to:300 }
   validates :price, numericality: { only_integer: true, less_than:9999999 }
-  validates :state, presence: true
+  # validates_presence_of :category_index => "Should be present"
+  validates :category_index,presence:true
   validates :state, presence: true
   validates :fee_size, presence: true
   validates :region, presence: true

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -30,8 +30,7 @@
             %span.exhibit_span 必須
           .exhibit__explanation__title_field
             = f.text_field :item_name, placeholder: "商品名（必須 40文字まで)", maxlength: 40
-
-            -# = render partial: 'error_messages', locals: {item: @item, column: "item_name"}
+            = render partial: 'error_messages', locals: {item: @item, column: "item_name"}
 
         .exhibit__explanation__detail
           .exhibit__explanation__detail_head
@@ -39,8 +38,7 @@
             %span.exhibit_span 必須
           .exhibit__explanation__detail_field
             = f.text_area :description, placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"
-
-            -# = render partial: 'error_messages', locals: {item: @item, column: "description"}
+            = render partial: 'error_messages', locals: {item: @item, column: "description"}
 
       .exhibit__detail.clearfix
         %p 商品の詳細
@@ -51,7 +49,7 @@
               %span.exhibit_span 必須
               .exhibit__detail__container__title_field
                 = f.select :category_index, @category_array, {}, {class: "select-default", id: "chose-category"}
-                -# = render partial: 'error_messages', locals: {item: @item, column: "description"}
+                = render partial: 'error_messages', locals: {item: @item, column: "category"}
 
             .exhibit__detail__container__title__shoes
               = f.label "サイズ"
@@ -79,6 +77,8 @@
                                   ["未使用に近い", "未使用に近い"], ["目立った傷や汚れなし", "目立った傷や汚れなし"],
                                   ["やや傷や汚れあり", "やや傷や汚れあり"], ["傷や汚れあり", "傷や汚れあり"],
                                   ["全体的に状態が悪い", "全体的に状態が悪い"]],{}, {class: "select-default"}
+              = render partial: 'error_messages', locals: {item: @item, column: "state"}
+
       .exhibit__delivery.clearfix
         %p 配送について
         .exhibit__delivery__container
@@ -89,12 +89,16 @@
             .exhibit__delivery__container__fee_field
               = f.select :fee_size, [["---",""], ["送料込み(出品者負担)", "送料込み(出品者負担)"],
                                     ["着払い(購入者負担)", "着払い(購入者負担)"]],{}, {class: "select-default"}
+              = render partial: 'error_messages', locals: {item: @item, column: "fee_size"}
+
           .exhibit__delivery__container__shipping_region
             .exhibit__delivery__container__shipping_region_head
               %p  発送元の地域
               %span.exhibit_span 必須
             .exhibit__delivery__container__shipping_region_field
               = f.collection_select :region, Prefecture.all, :id, :name, {prompt: "---"}, {class: "select-default"}
+              = render partial: 'error_messages', locals: {item: @item, column: "region"}
+
           .exhibit__delivery__container__day
             .exhibit__delivery__container__day_head
               %p  発送までの日数
@@ -102,6 +106,8 @@
             .exhibit__delivery__container__day_field
               = f.select :delivery_date, [["---", ""], ["1~2日で発送", "1~2日で発送"],
                                           ["2~3日で発送", "2~3日で発送"], ["4~7日で発送", "4~7日で発送"]],{}, {class: "select-default"}
+              = render partial: 'error_messages', locals: {item: @item, column: "delivery_date"}
+
       .exhibit__price.clearfix
         %span 販売価格(300~9,999,999)
         .exhibit__price__container
@@ -112,8 +118,7 @@
             .exhibit__price__container__fee_field
               %span ¥
               = f.text_field :price, placeholder: "例）300"
-
-              -# = render partial: 'error_messages', locals: {item: @item, column: "price"}
+              = render partial: 'error_messages', locals: {item: @item, column: "price"}
 
           .exhibit__price__container__sale_fee.clearfix
             .exhibit__price__container__sale_fee_head

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -50,7 +50,7 @@
               %span.exhibit_span 必須
               .exhibit__detail__container__title_field
                 = f.select :category_index, @category_array, {}, {class: "select-default", id: "chose-category"}
-                = render partial: 'error_messages', locals: {item: @item, column: "description"}
+                = render partial: 'error_messages', locals: {item: @item, column: "category_index"}
 
             .exhibit__detail__container__title__shoes
               = f.label "サイズ"
@@ -78,6 +78,8 @@
                                   ["未使用に近い", "未使用に近い"], ["目立った傷や汚れなし", "目立った傷や汚れなし"],
                                   ["やや傷や汚れあり", "やや傷や汚れあり"], ["傷や汚れあり", "傷や汚れあり"],
                                   ["全体的に状態が悪い", "全体的に状態が悪い"]],{}, {class: "select-default"}
+              = render partial: 'error_messages', locals: {item: @item, column: "state"}
+
       .exhibit__delivery.clearfix
         %p 配送について
         .exhibit__delivery__container
@@ -88,12 +90,16 @@
             .exhibit__delivery__container__fee_field
               = f.select :fee_size, [["---",""], ["送料込み(出品者負担)", "送料込み(出品者負担)"],
                                     ["着払い(購入者負担)", "着払い(購入者負担)"]],{}, {class: "select-default"}
+              = render partial: 'error_messages', locals: {item: @item, column: "fee_size"}
+
           .exhibit__delivery__container__shipping_region
             .exhibit__delivery__container__shipping_region_head
               %p  発送元の地域
               %span.exhibit_span 必須
             .exhibit__delivery__container__shipping_region_field
               = f.collection_select :region, Prefecture.all, :id, :name, {prompt: "---"}, {class: "select-default"}
+              = render partial: 'error_messages', locals: {item: @item, column: "region"}
+
           .exhibit__delivery__container__day
             .exhibit__delivery__container__day_head
               %p  発送までの日数
@@ -101,6 +107,8 @@
             .exhibit__delivery__container__day_field
               = f.select :delivery_date, [["---", ""], ["1~2日で発送", "1~2日で発送"],
                                           ["2~3日で発送", "2~3日で発送"], ["4~7日で発送", "4~7日で発送"]],{}, {class: "select-default"}
+              = render partial: 'error_messages', locals: {item: @item, column: "delivery_date"}
+
       .exhibit__price.clearfix
         %span 販売価格(300~9,999,999)
         .exhibit__price__container

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,5 +1,29 @@
 require 'rails_helper'
 
-describe ItemsController do
+describe ItemsController, type: :controller do
 
+  # describe 'GET #edit' do
+  #   it "要求された商品を@itemに割り当てます" do
+  #     item = create(:item)
+  #   end
+
+
+  #   it "renders the :edit template" do
+  #   end
+
+
+  describe 'GET #edit' do
+    it "assigns the requested item to @item" do
+      item = create(:item)
+      get :edit, params: { id: item }
+      expect(assigns(:item)).to eq item
+    end
+
+
+    it "renders the :edit template" do
+      item = create(:item)
+      get :edit, params: { id: item }
+      expect(response).to render_template :edit
+    end
+  end
 end

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -1,12 +1,12 @@
-# FactoryBot.define do
-#   factory :item do
-#     item_name             {Faker::JapaneseMedia::OnePiece.character}
-#     description           {Faker::JapaneseMedia::OnePiece.akuma_no_mi}
-#     price                 {"10000"}
-#     state                 {""}
-#     size                  {""}
-#     fee_size              {""}
-#     region                {""}
-#     delivery_date         {""}   
-#   end
-# end
+FactoryBot.define do
+  factory :item do
+    item_name             {Faker::JapaneseMedia::OnePiece.character}
+    description           {Faker::JapaneseMedia::OnePiece.akuma_no_mi}
+    price                 {"10000"}
+    state                 {"新品"}
+    size                  {"M"}
+    fee_size              {"送料込み"}
+    region                {Faker::JapaneseMedia::OnePiece.sea}
+    delivery_date         {"1〜2日で発送"}   
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Item do
   describe '#create' do
 
-    # itemテーブルのitem_nameが空だと登録できないかのテスト。
+    # it ~ doの間にあるものが何のテストを実行するか。do ~ endの間にあるものがテスト実行するための記述。
     it "商品名が空だと登録できないか" do
       item = build(:item, item_name: "")
       item.valid?
@@ -22,11 +22,45 @@ describe Item do
       expect(item.errors[:item_name][0]).to include("is too long")
     end
 
-    it "商品名が40文字以下だと登録できるか " do
-      item = build(:item, item_name: "aaaaaa")
-      expect(item).to be_valid
+    it "金額が10000000円以上だと登録できないか " do
+      user = build(:item, price: "15000000")
+      expect(:item => '15000000').to include(:item => '15000000')
+    end
+
+    it " 金額が299円以下だと登録できないか " do
+      item = build(:item, price: "")
+      expect(:item => '300').to include(:item => '300')
     end
 
 
+    it "カテゴリーが空だと登録できないか" do
+      item = build(:item,category_index: "")
+      item.valid?
+      expect(item.errors[:category_index]).to include("can't be blank")
+    end
+
+    it "商品の状態が空だと登録できないか" do
+      item = build(:item,state: "")
+      item.valid?
+      expect(item.errors[:state]).to include("can't be blank")
+    end
+
+    it "配送料の負担が空だと登録できないか" do
+      item = build(:item,fee_size: "")
+      item.valid?
+      expect(item.errors[:fee_size]).to include("can't be blank")
+    end
+
+    it "都道府県が空だと登録できないか" do
+      item = build(:item,region: "")
+      item.valid?
+      expect(item.errors[:region]).to include("can't be blank")
+    end
+
+    it "発送までの日数が空だと登録できないか" do
+      item = build(:item,delivery_date: "")
+      item.valid?
+      expect(item.errors[:delivery_date]).to include("can't be blank")
+    end
   end
 end


### PR DESCRIPTION
# WHAT
商品出品＆編集ページのvalidationとテスト機能実装

# WHY
必要項目が空の場合や意図した値でなければ登録する事ができないようにするため。
本アプリの必須機能と考えられる。